### PR TITLE
Issue#42: serial monitor restarts after program upload

### DIFF
--- a/src/main/java/de/fhg/iais/roberta/connection/wired/spike/SpikeConnector.java
+++ b/src/main/java/de/fhg/iais/roberta/connection/wired/spike/SpikeConnector.java
@@ -86,7 +86,7 @@ public class SpikeConnector extends AbstractConnector<Spike> {
                                 os.write(program.getFirst());
                             }
                             this.fire(State.WAIT_UPLOAD);
-                                Pair<Integer, String> result = this.spikeCommunicator.handleUpload(tmp.getAbsolutePath());
+                            Pair<Integer, String> result = this.spikeCommunicator.handleUpload(tmp.getAbsolutePath());
                             if ( result.getFirst() != 0 ) {
                                 this.fire(State.ERROR_UPLOAD_TO_ROBOT.setAdditionalInfo(result.getSecond()));
                                 this.fire(State.WAIT_FOR_CMD);

--- a/src/main/java/de/fhg/iais/roberta/ui/serialMonitor/SerialMonitorController.java
+++ b/src/main/java/de/fhg/iais/roberta/ui/serialMonitor/SerialMonitorController.java
@@ -50,11 +50,10 @@ public class SerialMonitorController implements IController {
         LOG.debug("setState: {}", state);
         switch ( state ) {
             case DISCOVER:
-                this.stopSerialLogging();
-                break;
             case WAIT_UPLOAD:
                 this.stopSerialLogging();
                 break;
+            case WAIT_FOR_CMD:
             case WAIT_EXECUTION:
                 if ( this.serialMonitorView.isVisible() ) {
                     this.restartSerialLogging();


### PR DESCRIPTION
This PR fixes [the issue](https://github.com/OpenRoberta/openroberta-connector/issues/42) that the serial monitor needed to be manually restarted after every upload of a program 