### PR TITLE
Removes serial monitor for spike

### DIFF
--- a/src/main/java/de/fhg/iais/roberta/connection/wired/spike/SpikeCommunicator.java
+++ b/src/main/java/de/fhg/iais/roberta/connection/wired/spike/SpikeCommunicator.java
@@ -209,7 +209,7 @@ public class SpikeCommunicator {
             if ( responseMatcher.find() ) {
                 return checkResponse(responseMatcher.group(), id, payload);
             }
-            Thread.sleep(100);
+            Thread.sleep(10);
         }
         LOG.error("Timeout: No response received from the robot");
         return new Pair<>(1, "No response received from the robot");

--- a/src/main/resources/robots.properties
+++ b/src/main/resources/robots.properties
@@ -28,8 +28,5 @@ festobionic.serial.baudrate=9600
 festobionicflower.serial
 festobionicflower.serial.baudrate=9600
 
-spike.serial
-spike.serial.baudrate=115200
-
 sensebox.serial
 sensebox.serial.baudrate=9600


### PR DESCRIPTION
This PR removes the serial monitor for the spike robot because for following reasons:
- Sensordata is littering the serial monitor
and when removing the sensordata by using the REPL mode and executing the program there:
- The robot needs to be restarted for every new program upload
- The robots center button does not stop a running program